### PR TITLE
Pagination

### DIFF
--- a/src/main/java/dev/otthon/jobbank/api/skills/assemblers/SkillAssembler.java
+++ b/src/main/java/dev/otthon/jobbank/api/skills/assemblers/SkillAssembler.java
@@ -36,7 +36,7 @@ public class SkillAssembler implements SimpleRepresentationModelAssembler<SkillR
     // Para adicionar os links na API Heteoas para um conjunto de recursos
     @Override
     public void addLinks(CollectionModel<EntityModel<SkillResponseDTO>> resources) {
-        var selfLink = WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(SkillRestController.class).findAll())
+        var selfLink = WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(SkillRestController.class).findAll(null))
                 .withSelfRel()
                 .withType("GET");
 

--- a/src/main/java/dev/otthon/jobbank/api/skills/controllers/SkillRestController.java
+++ b/src/main/java/dev/otthon/jobbank/api/skills/controllers/SkillRestController.java
@@ -9,6 +9,8 @@ import dev.otthon.jobbank.core.repositories.SkillRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.BeanUtils;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.http.HttpStatus;
@@ -23,15 +25,14 @@ public class SkillRestController {
     private final SkillMapper skillMapper;
     private final SkillRepository skillRepository;
     private final SkillAssembler skillAssembler;
+    private final PagedResourcesAssembler<SkillResponseDTO> pagedResourcesAssembler;
 
     @GetMapping
-    public CollectionModel<EntityModel<SkillResponseDTO>> findAll() {
-        var skills =  skillRepository.findAll()
-                .stream()
-                .map(skillMapper::toSkillResponseDTO)
-                .toList();
-        // Montando o HATEOAS
-        return skillAssembler.toCollectionModel(skills);
+    public CollectionModel<EntityModel<SkillResponseDTO>> findAll(Pageable pageable) {
+        var skills = skillRepository.findAll(pageable)
+                .map(skillMapper::toSkillResponseDTO);
+
+        return pagedResourcesAssembler.toModel(skills, skillAssembler);
     }
 
     @GetMapping("/{id}")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,17 +1,32 @@
 spring.application.name=job-bank
 
-# H2 Database
+##### H2 Database
 spring.datasource.url=jdbc:h2:mem:job-bank
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=root
 spring.datasource.password=root
 
-# JPA Configuration
+##### JPA Configuration
 spring.jpa.show-sql=true
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
-# Hibernate Configuration
+##### Hibernate Configuration
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
+
+##### Pagination Configuration
+# Por padrão a páginação começa em 0 (false), para começar a contagem por 1 use true
+spring.data.web.pageable.one-indexed-parameters=true
+# Por padrão o tamanho da lista de retorno é 20
+spring.data.web.pageable.default-page-size=50
+# O cliente pode solicitar o tamanho de itens na página até 2000 por padrão
+spring.data.web.pageable.max-page-size=10
+# Padrão de parametro a ser passado é page
+spring.data.web.pageable.page-parameter=size
+# Padrão de parametro a ser passado é parameter
+spring.data.web.pageable.size-parameter=tamanho
+
+
+


### PR DESCRIPTION
Paginação em uma API REST é uma técnica usada para dividir uma grande quantidade de dados em partes menores, facilitando assim a transferência e o processamento dessas informações. Em vez de retornar todos os registros de uma vez, a API retorna um subconjunto de dados em cada resposta, junto com informações sobre como acessar os outros subconjuntos.

## Parâmetros de Paginação
As APIs geralmente usam parâmetros de consulta (query parameters) para controlar a paginação. Os parâmetros comuns incluem:

- **page:** O número da página atual.
- **size:** O número de itens por página.
- **offset:** A posição inicial dos itens a serem retornados.
- **limit:** O número máximo de itens a serem retornados.

## Exemplo de Requisição Paginada
Pode-se fazer uma requisição `GET` para o endpoint `/users` e especificar os parâmetros de paginação como `page`, `size`, e `sort`:
```
GET /users?page=2&size=10&sort=name,asc
````
Essa configuração torna a paginação flexível e fácil de usar, permitindo que você controle como os dados são paginados e ordenados com base em parâmetros de consulta.

## Estrutura de uma resposta
```json
 {
  "content": [
    { "id": 1, "name": "John Doe" },
    { "id": 2, "name": "Jane Doe" },
    // ... outros usuários
  ],
  "page": 1,
  "size": 10,
  "totalElements": 50,
  "totalPages": 5,
  "links": {
    "next": "/users?page=2&size=10",
    "prev": null,
    "first": "/users?page=1&size=10",
    "last": "/users?page=5&size=10"
  }
}
```

- **content:** Os dados da página atual.
- **page:** O número da página atual.
- **size:** O número de itens por página.
- **totalElements:** O número total de itens disponíveis.
- **totalPages:** O número total de páginas.
- **links:** Links para navegar entre as páginas.

## Customização das propriedades da paginação
No Spring Boot, você pode customizar as propriedades de paginação no arquivo `application.properties` usando a configuração `spring.data.web.pageable.*`. Isso permite definir valores padrão para paginação, como o tamanho da página, a página inicial, e até mesmo os nomes dos parâmetros de consulta usados para paginação. Aqui está um exemplo de como você pode configurar essas propriedades:

1. `spring.data.web.pageable.default-page-size` : Define o tamanho padrão da página. Este é o número de itens que serão retornados por página se o cliente não especificar um valor diferente.
2. `spring.data.web.pageable.max-page-size` : Define o tamanho máximo da página. Este é o limite máximo de itens que podem ser retornados por página, independentemente do que o cliente solicitar.
3. `spring.data.web.pageable.one-indexed-parameters` : Define se os índices das páginas são baseados em 1 em vez de 0. Se for true, a primeira página será 1 em vez de 0.
4. `spring.data.web.pageable.page-parameter` : Define o nome do parâmetro de consulta que será usado para especificar o número da página.
5. `spring.data.web.pageable.size-parameter` : Define o nome do parâmetro de consulta que será usado para especificar o tamanho da página (quantidade de itens por página).
6. `spring.data.web.sort.sort-parameter` : Define o nome do parâmetro de consulta que será usado para especificar a ordenação dos resultados.

## Exemplo de Requisição
Com a configuração acima, você pode fazer uma requisição `GET` para o endpoint `/users` e especificar os parâmetros de paginação como `page`, `size`, e `sort`:
```
GET /users?page=2&size=10&sort=name,asc
````
Essa configuração torna a paginação flexível e fácil de usar, permitindo que você controle como os dados são paginados e ordenados com base em parâmetros de consulta.